### PR TITLE
index.vue 新規作成とテンプレートの分離

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": false
+}

--- a/index.html
+++ b/index.html
@@ -2,18 +2,39 @@
 <html lang="ja">
 
     <head>
-        <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
-        <link href="https://unpkg.com/vuetify@3.6.6/dist/vuetify.min.css" rel="stylesheet">
         <meta name="viewport"
-            content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
+            content="
+                width=device-width,
+                initial-scale=1,
+                maximum-scale=1,
+                user-scalable=no,
+                minimal-ui
+            " />
+        <meta charset="UTF-8">
+        <title>Vuetify 3 CDN Test</title>
+
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" />
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify.min.css" />
     </head>
 
     <body>
         <div id="app"></div>
 
-        <script src="https://unpkg.com/vue@3.4.27/dist/vue.global.js"></script>
-        <script src="https://unpkg.com/vuetify@3.6.6/dist/vuetify.min.js"></script>
-        <script type="module" src="./index.js"></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/vue@3.4.38/dist/vue.global.prod.js"></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/vue-router@4.2.5/dist/vue-router.global.prod.js"></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify.min.js"></script>
+        <script
+            src="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify-labs-components.min.js"></script>
+        <script
+            type="module"
+            src="./index.js"></script>
     </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" />
         <link
             rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify.min.css" />
+            href="https://cdn.jsdelivr.net/npm/vuetify@3.6.6/dist/vuetify.min.css" />
     </head>
 
     <body>

--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
         <div id="app"></div>
 
         <script
-            src="https://cdn.jsdelivr.net/npm/vue@3.4.38/dist/vue.global.prod.js"></script>
+            src="https://cdn.jsdelivr.net/npm/vue@3.4.27/dist/vue.global.prod.js"></script>
         <script
             src="https://cdn.jsdelivr.net/npm/vue-router@4.2.5/dist/vue-router.global.prod.js"></script>
         <script
-            src="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify.min.js"></script>
+            src="https://cdn.jsdelivr.net/npm/vuetify@3.6.6/dist/vuetify.min.js"></script>
         <script
-            src="https://cdn.jsdelivr.net/npm/vuetify@3.7.19/dist/vuetify-labs-components.min.js"></script>
+            src="https://cdn.jsdelivr.net/npm/vuetify@3.6.6/dist/vuetify-labs-components.min.js"></script>
         <script
             type="module"
             src="./index.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,62 +1,61 @@
 const { createApp, ref, onMounted } = Vue
 const { createVuetify } = Vuetify
+//const { createRouter, createWebHistory } = VueRouter
 
 const vuetify = createVuetify()
-createApp({
-    setup() {
-        const visual = ref(false);
-        const info = ref({
-            name: "",
-            nickname: "",
-            gender: "",
-        });
-        const drawer = ref(null);
+/*
+const router = createRouter({
+    history: createWebHistory(),
+    routes: [{
+        path: '/',
+        component: {
+            template: '<div>RouterTemplate</div>'
+        }
+    }]
+})
+*/
+const headers = {
+    headers: {
+        "Content-Type": "text/x-vue",
+    }
+};
 
-        /**
-         * 初期表示時にナビゲーションドロワーを開く
-         */
-        onMounted(() => {
-            drawer.value = true;
-        });
+/** メインアプリケーションの作成とマウント
+ * - index.vue をフェッチしてテンプレートとして使用
+ */
+fetch('./index.vue', headers)
+    .then(r => r.text())
+    .then(vue => {
+        const app = createApp({
+            template: vue,
+            setup() {
+                const visual = ref(false);
+                const info = ref({
+                    name: "",
+                    nickname: "",
+                    gender: "",
+                });
+                const drawer = ref(null);
 
-        return {
-            visual,
-            info,
-            drawer,
-        };
-    },
-    template: `
-            <v-app>
-            <v-app-bar app>
-                <!-- ヘッドバー  -->
-                <v-app-bar-nav-icon @click="drawer = !drawer"></v-app-bar-nav-icon>
-                <v-toolbar-title>Application</v-toolbar-title>
-                <div class='foo' style='margin-left: auto;'>
+                /**
+                 * 初期表示時にナビゲーションドロワーを開く
+                 */
+                onMounted(() => {
+                    drawer.value = true;
+                });
 
-                </div>
-            </v-app-bar>
+                return {
+                    visual,
+                    info,
+                    drawer,
+                };
+            },
+        })
 
-            <v-navigation-drawer v-model="drawer" app>
-                <!-- サイドメニューバー  -->
-                <v-expansion-panels>
-                    <v-expansion-panel v-for="i in 3" :key="i" title="Item"
-                        text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."></v-expansion-panel>
-                </v-expansion-panels>
-            </v-navigation-drawer>
-
-            <v-main>
-                <!-- メインコンテンツ  -->
-                <div>
-                    <v-btn>
-                        push
-                    </v-btn>
-                </div>
-                <v-row no-gutters>
-                    <v-col v-for="n in 25" :key="n">
-                        <v-card width="300" height="600" outlined>Card</v-card>
-                    </v-col>
-                </v-row>
-            </v-main>
-        </v-app>
-    `,
-}).use(vuetify).mount('#app');
+        //app.use(router)
+        app.use(vuetify)
+        app.mount('#app')
+    })
+    .catch(err => {
+        console.error('index.vueの読み込みに失敗:', err);
+    });

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-const { createApp, ref, onMounted } = Vue
+const { createApp, ref, onMounted, watch } = Vue
 const { createVuetify } = Vuetify
-//const { createRouter, createWebHistory } = VueRouter
+const { createRouter, createWebHistory, useRoute } = VueRouter
 
 const vuetify = createVuetify()
-/*
+
 const router = createRouter({
     history: createWebHistory(),
     routes: [{
@@ -13,7 +13,7 @@ const router = createRouter({
         }
     }]
 })
-*/
+
 const headers = {
     headers: {
         "Content-Type": "text/x-vue",
@@ -25,7 +25,12 @@ const headers = {
  */
 fetch('./index.vue', headers)
     .then(r => r.text())
-    .then(vue => {
+    .then(xml => {
+        /* template部分を抽出しないといけないので、タグを削除する
+         * index.vue の中身をそのまま使うわけにはいかない
+         * index.vue は template タグで囲まれていないとVueファイルと認識されないため
+         */
+        const vue = xml.replace('<template>', '').replace('</template>', '');
         const app = createApp({
             template: vue,
             setup() {
@@ -35,13 +40,19 @@ fetch('./index.vue', headers)
                     nickname: "",
                     gender: "",
                 });
-                const drawer = ref(null);
 
-                /**
-                 * 初期表示時にナビゲーションドロワーを開く
-                 */
-                onMounted(() => {
+                // 初期表示時にナビゲーションドロワーを開く
+                // 幅1280px未満はモバイル扱いで閉じられる
+                const drawer = ref(true);
+
+                const route = useRoute();
+
+                // ルートが変わるたびにドロワーを開く
+                watch(() => route.fullPath, () => {
                     drawer.value = true;
+                });
+
+                onMounted(() => {
                 });
 
                 return {
@@ -52,7 +63,7 @@ fetch('./index.vue', headers)
             },
         })
 
-        //app.use(router)
+        app.use(router)
         app.use(vuetify)
         app.mount('#app')
     })

--- a/index.vue
+++ b/index.vue
@@ -1,0 +1,56 @@
+<template>
+    <v-app>
+        <v-app-bar app>
+            <!-- ヘッドバー  -->
+            <v-app-bar-nav-icon
+                @click="drawer = !drawer"
+                >
+            </v-app-bar-nav-icon>
+            <v-toolbar-title>Application</v-toolbar-title>
+            <div
+                class='foo'
+                style='margin-left: auto;'
+                >
+            </div>
+        </v-app-bar>
+
+        <v-navigation-drawer
+            v-model="drawer"
+            app
+            >
+            <!-- サイドメニューバー  -->
+            <v-expansion-panels>
+                <v-expansion-panel
+                    v-for="i in 3"
+                    :key="i"
+                    title="Item"
+                    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                >
+                </v-expansion-panel>
+            </v-expansion-panels>
+        </v-navigation-drawer>
+
+        <v-main>
+            <!-- メインコンテンツ  -->
+            <div>
+                <v-btn>
+                    push
+                </v-btn>
+            </div>
+            <v-row no-gutters>
+                <v-col
+                    v-for="n in 25"
+                    :key="n"
+                    >
+                    <v-card
+                        width="300"
+                        height="600"
+                        outlined
+                        >
+                        Card
+                    </v-card>
+                </v-col>
+            </v-row>
+        </v-main>
+    </v-app>
+</template>


### PR DESCRIPTION
### 概要
- これまで index.js 内に記述していたテンプレート部分を Vue ファイルへ移動
- 新規に index.vue を作成し、Vuetify コンポーネントを用いたレイアウトを定義
- コードの責務を分離し、保守性を向上

### 変更内容
- index.vue を新規作成し、AppBar・Navigation Drawer・Expansion Panel・Main コンテンツを記述
- index.js からテンプレート部分を削除し、Vue ファイルをフェッチして利用するよう修正
- VSCode 設定追加（最終改行の自動挿入、改行の自動Trim無効化）
- index.html の CDN URL を更新し、Vue/Vuetify のバージョンを調整

### 目的
- JS ファイルと Vue テンプレートを分離し、コードの見通しを改善
- Vuetify3 を CDN 経由で利用しつつ、Vue Router による画面遷移に対応
- 開発効率と保守性の向上
